### PR TITLE
Rename library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .stack-work/
 *.cabal
 *~
-src/IFS/Test.hs

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Iterative Forward Search
 
-![MIT](https://img.shields.io/github/license/fpclass/ifs)
-[![CI](https://github.com/fpclass/ifs/actions/workflows/haskell.yaml/badge.svg)](https://github.com/fpclass/ifs/actions/workflows/haskell.yaml)
-[![stackage-nightly](https://github.com/fpclass/ifs/actions/workflows/stackage-nightly.yaml/badge.svg)](https://github.com/fpclass/ifs/actions/workflows/stackage-nightly.yaml)
-[![ifs](https://img.shields.io/hackage/v/ifs)](https://hackage.haskell.org/package/ifs)
+![MIT](https://img.shields.io/github/license/fpclass/iterative-forward-search)
+[![CI](https://github.com/fpclass/iterative-forward-search/actions/workflows/haskell.yaml/badge.svg)](https://github.com/fpclass/iterative-forward-search/actions/workflows/haskell.yaml)
+[![stackage-nightly](https://github.com/fpclass/iterative-forward-search/actions/workflows/stackage-nightly.yaml/badge.svg)](https://github.com/fpclass/iterative-forward-search/actions/workflows/stackage-nightly.yaml)
+[![iterative-forward-search](https://img.shields.io/hackage/v/iterative-forward-search)](https://hackage.haskell.org/package/iterative-forward-search)
 
 This library implements a contraint solver via the [iterative forward search algorithm](https://muller.unitime.org/lscs04.pdf). It also includes a helper module specifically for using the algorithm to timetable events.
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
-name:                ifs
+name:                iterative-forward-search
 version:             0.1.0.0
-github:              "fpclass/ifs"
+github:              "fpclass/iterative-forward-search"
 license:             MIT
 author:              "Michael B. Gale and Oscar Harris"
 maintainer:          "m.gale@warwick.ac.uk"
@@ -38,7 +38,7 @@ library:
   source-dirs: src
 
 benchmarks:
-  ifs-bench:
+  iterative-forward-search-bench:
     main:                Main.hs
     source-dirs:         bench
     ghc-options:
@@ -46,5 +46,5 @@ benchmarks:
       - -rtsopts
       - -with-rtsopts=-N
     dependencies:
-      - ifs
+      - iterative-forward-search
       - criterion


### PR DESCRIPTION
This renames the library so it doesn't clash with an existing hackage package. Should be merged at the same time the repo itself is renamed. Also culls an old line from `.gitignore` which came up when I did a search for ifs.

Closes #3.